### PR TITLE
change the name of declaration file

### DIFF
--- a/src/generator/Adapters/TypeTemplatesCreator.ts
+++ b/src/generator/Adapters/TypeTemplatesCreator.ts
@@ -136,7 +136,7 @@ class TypeTemplatesCreator extends TypeGenerator {
     let typeTemplate, fileName;
 
     if (env === 'decl') {
-      fileName = 'index.d';
+      fileName = 'TailwindStylingObject.d';
       typeTemplate = `${imports}\n\ndeclare module "${moduleName}" {\n interface TailwindStylingObject {\n${properties}\n} \n}`;
     } else {
       fileName = 'index';


### PR DESCRIPTION
Change the name of declaration file to TailwindStylingObject.d.ts because index.d.ts loses its effect when there is another file named 'index.ts' in the directory. This scenario occurs when `decl` and `dev` mode are executed